### PR TITLE
Properly initialize buffer when output token length is zero.

### DIFF
--- a/ngx_http_auth_spnego_module.c
+++ b/ngx_http_auth_spnego_module.c
@@ -876,6 +876,9 @@ ngx_http_auth_spnego_auth_user_gss(
         ngx_encode_base64(&ctx->token_out_b64, &spnego_token);
         gss_release_buffer(&minor_status2, &output_token);
     }
+	else {
+        ctx->token_out_b64.len = 0;
+	}
 
     /* getting user name at the other end of the request */
     major_status = gss_display_name(&minor_status, client_name, &output_token, NULL);


### PR DESCRIPTION
Uninitialized variable was used for the buffer size leading to memory
allocation errors.

Failure was observable using command line tools such as curl and Perl.